### PR TITLE
Implement completion screen after exam submission

### DIFF
--- a/src/pages/Student/Student.vue
+++ b/src/pages/Student/Student.vue
@@ -97,7 +97,7 @@ function toggleSubmitExamModal() {
 async function handleExamSubmit() {
   isDoneWithExam.value = true;
   clearInterval(intervalId!);
-  router.push("/student-login");
+  router.replace(`/student/${examID.value}/done`);
   documentResult.value.forEach((q, i) => (q.studentAnswer = answers.value[i]));
   const html = questionFormatTeacher(documentResult.value);
   const pdfBlob = await generatePdfBlob(html);

--- a/src/pages/Student/SubmissionNotification.vue
+++ b/src/pages/Student/SubmissionNotification.vue
@@ -1,14 +1,39 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import {
+  onMounted,
+  onUnmounted,
+} from "vue";
+import {
+  useRouter,
+} from "vue-router";
+
+const router = useRouter();
+
+function preventBack() {
+  window.history.pushState(null, "", window.location.href);
+}
+
+onMounted(() => {
+  preventBack();
+  window.addEventListener("popstate", preventBack);
+  setTimeout(() => {
+    window.removeEventListener("popstate", preventBack);
+    router.replace("/student-login");
+  }, 5000);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("popstate", preventBack);
+});
+</script>
 
 <template>
   <section
     class="bg-gray-800 w-screen h-screen text-white flex flex-col items-center justify-center gap-4 p-4"
   >
-    <p class="text-[10vh]">
-      Thank You!
-    </p>
-    <p class="text-5xl text-center">
-      Your grade will be sent you by your teacher.
+    <p class="text-5xl text-center text-wrap">
+      You have completed this exam. Your results will be sent by instructor in
+      due time.
     </p>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- replace exam submission navigation with route to completion page
- show completion page that redirects to login after 5 seconds
- block browser back navigation on completion page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68420e3e10e8832eb7286f1d9ac2dbd5