### PR TITLE
Implement logout request and use questions from login

### DIFF
--- a/src/pages/Auth/StudentLogin.vue
+++ b/src/pages/Auth/StudentLogin.vue
@@ -9,6 +9,9 @@ import {
 } from "vue-router";
 
 import {
+  useDocumentStore,
+} from "../../store/server/document";
+import {
   axiosInstance,
 } from "../../utils/axiosConfig";
 import {
@@ -42,6 +45,12 @@ async function onSubmit() {
     } = await axiosInstance.post(`/exams/${loginForm.examKey}`, {
       email: loginForm.email.toLowerCase(),
     });
+
+    const documentStore = useDocumentStore();
+    const questions = data.questions || data.exam?.questions;
+    if (questions) {
+      documentStore.setQuestions(questions);
+    }
 
     document.cookie = `student=${data.access_token}; Path=/; Secure; SameSite=Strict`;
     localStorage.setItem("email", loginForm.email.toLowerCase());

--- a/src/pages/Student/Student.vue
+++ b/src/pages/Student/Student.vue
@@ -57,6 +57,7 @@ const {
   getPdfFromCloudinary,
   generatePdfBlob,
   uploadPdfToCloudinary,
+  setQuestions,
 } = documentStore;
 
 const {
@@ -146,10 +147,16 @@ onMounted(async () => {
   await getExam({
     id: examID.value,
   });
-  const file = await getPdfFromCloudinary(exam.value!.question);
-  await uploadDocument({
-    file,
-  }, false);
+  const stored = localStorage.getItem("studentQuestions");
+  if (stored) {
+    setQuestions(JSON.parse(stored));
+  }
+  else {
+    const file = await getPdfFromCloudinary(exam.value!.question);
+    await uploadDocument({
+      file,
+    }, false);
+  }
   answers.value = documentResult.value.map(() => "");
   remainingTime.value = timeLimit.value;
   if (timeLimit.value > 0 && mode.value === "student") {
@@ -373,7 +380,12 @@ watch(timeLimit, (lim) => {
             <AppRadio
               v-if="q.type === 'multiple-choice'"
               v-model="answers[idx]"
-              :items="q.options.map((opt) => sanitize(opt))"
+              :items="
+                q.options.map((opt, i) => ({
+                  label: `${String.fromCharCode(65 + i)}. ${sanitize(opt)}`,
+                  value: sanitize(opt),
+                }))
+              "
               class="pl-5"
               :disabled="isDoneWithExam"
             />

--- a/src/store/server/auth.ts
+++ b/src/store/server/auth.ts
@@ -54,7 +54,8 @@ export const useAuthStore = defineStore("auth", {
       }
       catch (error: any) {
         this.success = false;
-        const errorMessage = error.response?.data?.message || error.message || "Network Error";
+        const errorMessage
+          = error.response?.data?.message || error.message || "Network Error";
         errorToast(errorMessage);
         throw new Error(errorMessage);
       }
@@ -78,7 +79,8 @@ export const useAuthStore = defineStore("auth", {
       }
       catch (error: any) {
         this.success = false;
-        const errorMessage = error.response?.data?.message || error.message || "Network Error";
+        const errorMessage
+          = error.response?.data?.message || error.message || "Network Error";
         errorToast(errorMessage);
         throw new Error(errorMessage);
       }
@@ -108,12 +110,22 @@ export const useAuthStore = defineStore("auth", {
       }
     },
 
-    logout() {
-      this.clearAccessToken();
-      this.clearToken("name");
-      router.push({
-        name: "login",
-      });
+    async logout() {
+      try {
+        await axiosInstance.post("/logout");
+      }
+      catch (error: any) {
+        const errorMessage
+          = error.response?.data?.message || error.message || "Network Error";
+        errorToast(errorMessage);
+      }
+      finally {
+        this.clearAccessToken();
+        this.clearToken("name");
+        router.push({
+          name: "login",
+        });
+      }
     },
   },
   getters: {

--- a/src/store/server/document.ts
+++ b/src/store/server/document.ts
@@ -227,5 +227,20 @@ export const useDocumentStore = defineStore("documents", {
         this.loading = false;
       }
     },
+
+    setQuestions(questions: Array<{
+      type: string;
+      question: string;
+      options: string[];
+      answer?: string;
+    }>) {
+      this.result = questions.map(q => ({
+        type: q.type,
+        question: q.question,
+        options: q.options ?? [],
+        answer: "",
+      }));
+      localStorage.setItem("studentQuestions", JSON.stringify(this.result));
+    },
   },
 });


### PR DESCRIPTION
## Summary
- call API to logout and clear tokens
- store questions returned on student login
- load saved questions when showing student exam
- label multiple choice options alphabetically

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684319bbcce0832e8c8d0a67f0bf385e