### PR TITLE
Store exam key for processing and creation

### DIFF
--- a/src/store/server/document.ts
+++ b/src/store/server/document.ts
@@ -50,9 +50,12 @@ export const useDocumentStore = defineStore("documents", {
         const formData = new FormData();
         formData.append("file", payload.file);
 
+        const examKey = localStorage.getItem("examKey");
+        const url = examKey ? `/process/${examKey}` : "/process";
+
         const {
           data: initial,
-        } = await axiosInstance.post("/process", formData, {
+        } = await axiosInstance.post(url, formData, {
           headers: {
             "Content-Type": "multipart/form-data",
           },


### PR DESCRIPTION
## Summary
- keep a temporary `examKey` in localStorage when starting new exam creation
- send the stored key while processing uploaded files
- use the same key when saving a new exam and clean it up afterwards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684329041600832eabf87bf0fa765e2d