### PR TITLE
Use questions from login response

### DIFF
--- a/src/pages/Auth/StudentLogin.vue
+++ b/src/pages/Auth/StudentLogin.vue
@@ -65,7 +65,7 @@ async function onSubmit() {
     });
 
     const documentStore = useDocumentStore();
-    const questions = data.questions || data.exam?.questions;
+    const questions = data.exam?.question_text || data.questions;
     if (questions) {
       documentStore.setQuestions(questions);
     }
@@ -74,6 +74,7 @@ async function onSubmit() {
     localStorage.setItem("email", loginForm.email.toLowerCase());
 
     localStorage.setItem("examKey", loginForm.examKey);
+    localStorage.setItem("examStartTime", String(Date.now()));
 
     router.push(`/student/${data.exam._id}?mode=student`);
   }

--- a/src/pages/Auth/StudentLogin.vue
+++ b/src/pages/Auth/StudentLogin.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import {
   computed,
+  onMounted,
+  onUnmounted,
   reactive,
   ref,
 } from "vue";
@@ -35,6 +37,22 @@ const inputUI = {
 };
 const isFormComplete = computed(() => {
   return loginForm.email !== "" && loginForm.examKey !== "";
+});
+
+function preventBack() {
+  window.history.pushState(null, "", window.location.href);
+}
+
+onMounted(() => {
+  if (sessionStorage.getItem("no-back")) {
+    preventBack();
+    window.addEventListener("popstate", preventBack);
+    sessionStorage.removeItem("no-back");
+  }
+});
+
+onUnmounted(() => {
+  window.removeEventListener("popstate", preventBack);
 });
 
 async function onSubmit() {

--- a/src/pages/Student/Student.vue
+++ b/src/pages/Student/Student.vue
@@ -68,7 +68,7 @@ const {
 
 const answers = ref<string[]>([]);
 
-const examStartTime = ref(Date.now());
+const examStartTime = ref(Number(localStorage.getItem("examStartTime")) || Date.now());
 
 const timeLimit = computed(() => (exam.value?.settings?.general.timeLimit || 0) * 60);
 const remainingTime = ref(0);
@@ -124,6 +124,9 @@ async function handleExamSubmit() {
       "Content-Type": "multipart/form-data",
     },
   });
+  localStorage.removeItem("examStartTime");
+  localStorage.removeItem("studentQuestions");
+  localStorage.removeItem("examKey");
   toggleSubmitExamModal();
 }
 
@@ -157,7 +160,9 @@ onMounted(async () => {
   if (timeLimit.value > 0 && mode.value === "student") {
     startTimer(true);
   }
-  examStartTime.value = Date.now();
+  if (!localStorage.getItem("examStartTime"))
+    localStorage.setItem("examStartTime", String(Date.now()));
+  examStartTime.value = Number(localStorage.getItem("examStartTime"));
   const ms = (60 - now.value.getSeconds()) * 1000;
   timer = window.setTimeout(() => {
     now.value = new Date();

--- a/src/pages/Student/SubmissionNotification.vue
+++ b/src/pages/Student/SubmissionNotification.vue
@@ -17,7 +17,7 @@ onMounted(() => {
   preventBack();
   window.addEventListener("popstate", preventBack);
   setTimeout(() => {
-    window.removeEventListener("popstate", preventBack);
+    sessionStorage.setItem("no-back", "1");
     router.replace("/student-login");
   }, 5000);
 });


### PR DESCRIPTION
## Summary
- capture log-in redirection on the student login page so the browser can't go back
- read stored questions in the Student view instead of re-processing the PDF
- track exam start time and send time spent when submitting
- persist back-navigation prevention between pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68456a581b58832e9cfb651ac61ef63b