### PR TITLE
Switch Cloudinary storage to AWS upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@ckeditor/ckeditor5-vue": "^7.3.0",
-        "@cloudinary/url-gen": "^1.21.0",
-        "@cloudinary/vue": "^1.13.1",
         "@nuxt/ui": "^3.1.0",
         "@tailwindcss/vite": "^4.0.12",
         "axios": "^1.8.4",
@@ -1138,65 +1136,6 @@
         "@clack/core": "0.4.2",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
-      }
-    },
-    "node_modules/@cloudinary/html": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@cloudinary/html/-/html-1.13.2.tgz",
-      "integrity": "sha512-AosYYA3TLz5astKokgAxRwlSNGCe1Z62EdA6vwgV/TrZ5y+yc7uHa9cRkSoi1M8GTA2aZvTWo6E2nxUZhNVpSg==",
-      "dependencies": {
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/lodash.debounce": "^4.0.6",
-        "@types/node": "^14.14.10",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.debounce": "^4.0.8",
-        "typescript": "^4.1.2"
-      }
-    },
-    "node_modules/@cloudinary/html/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
-    },
-    "node_modules/@cloudinary/html/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/@cloudinary/transformation-builder-sdk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@cloudinary/transformation-builder-sdk/-/transformation-builder-sdk-1.16.1.tgz",
-      "integrity": "sha512-Mh1qYMkoDxSAzbt0qY9NJaZrdH/vFBcrpeVWmbTXbPVDZHLaaLyJ2+RDFGger5lycbrehPLoNp2hh22BvhkvbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@cloudinary/url-gen": "^1.7.0"
-      }
-    },
-    "node_modules/@cloudinary/url-gen": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@cloudinary/url-gen/-/url-gen-1.21.0.tgz",
-      "integrity": "sha512-ctYcCzX3G3vcgnESTU2ET3K1XsBiXcEnBddCGV0QbR3fJhLLrIShjSMEwZoepgh4LAFOHJu9DzvLFr+E8R7c7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@cloudinary/transformation-builder-sdk": "^1.15.1"
-      }
-    },
-    "node_modules/@cloudinary/vue": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@cloudinary/vue/-/vue-1.13.1.tgz",
-      "integrity": "sha512-b5aabGTkW6n5J83dl4rE16WUVEQXPfDMc/1wcpDa0lZ8CJS7Om4Iljhv/78y02wZkyBMOSsij3ZvxJIMYUtTuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@cloudinary/html": "^1.13.2"
       }
     },
     "node_modules/@dprint/formatter": {
@@ -3192,24 +3131,6 @@
       "version": "4.17.12",
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
-      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.debounce": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
-      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -7325,18 +7246,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-vue": "^7.3.0",
-    "@cloudinary/url-gen": "^1.21.0",
-    "@cloudinary/vue": "^1.13.1",
     "@nuxt/ui": "^3.1.0",
     "@tailwindcss/vite": "^4.0.12",
     "axios": "^1.8.4",

--- a/src/layout/NewExamLayout.vue
+++ b/src/layout/NewExamLayout.vue
@@ -63,7 +63,7 @@ const {
 }
   = storeToRefs(useExamServerStore());
 const {
-  uploadPdfToCloudinary,
+  uploadPdfToS3,
   uploadDocument,
   generatePdfBlob,
 }
@@ -95,7 +95,7 @@ async function submitExam() {
   const file = await generatePdfBlob(newExamStore.editorContent);
   const {
     url,
-  } = await uploadPdfToCloudinary(file);
+  } = await uploadPdfToS3(file);
   if (!documentResult.value) {
     await uploadDocument({
       file,
@@ -131,7 +131,7 @@ async function handleQuestionUpdate() {
   const file = await generatePdfBlob(newExamStore.editorContent);
   const {
     url,
-  } = await uploadPdfToCloudinary(file);
+  } = await uploadPdfToS3(file);
   if (!documentResult.value) {
     await uploadDocument({
       file,

--- a/src/pages/MonitoringResults/MonitoringResults.vue
+++ b/src/pages/MonitoringResults/MonitoringResults.vue
@@ -51,7 +51,7 @@ const {
 const documentStore = useDocumentStore();
 const {
   loading: documentLoading,
-  getPdfFromCloudinary,
+  getPdfFromUrl,
 } = documentStore;
 
 const route = useRoute();
@@ -281,7 +281,7 @@ function exportCsv() {
 async function toggleTranscriptModal(transcriptUrl: string) {
   if (!transcriptUrl)
     return;
-  const file = await getPdfFromCloudinary(transcriptUrl);
+  const file = await getPdfFromUrl(transcriptUrl);
   if (!file)
     return;
   studentsTransciptUrl.value = URL.createObjectURL(file);

--- a/src/pages/NewExam/NewQuestion.vue
+++ b/src/pages/NewExam/NewQuestion.vue
@@ -30,7 +30,7 @@ const newExamStore = useNewExamStore();
 const documentStore = useDocumentStore();
 const {
   uploadDocument,
-  getPdfFromCloudinary,
+  getPdfFromUrl,
 } = useDocumentStore();
 const {
   increaseFormStepTwoCounter,
@@ -164,7 +164,7 @@ onMounted(async () => {
     await getExam({
       id: route.params.id as string,
     });
-    const file = await getPdfFromCloudinary(exam.value.question);
+    const file = await getPdfFromUrl(exam.value.question);
     await uploadDocument({
       file,
     }, false);

--- a/src/pages/Preview/Preview.vue
+++ b/src/pages/Preview/Preview.vue
@@ -37,7 +37,7 @@ const {
 }
   = storeToRefs(useDocumentStore());
 const {
-  getPdfFromCloudinary,
+  getPdfFromUrl,
   uploadDocument,
 } = useDocumentStore();
 const {
@@ -58,7 +58,7 @@ onMounted(async () => {
   await getExam({
     id: examID.value,
   });
-  const file = await getPdfFromCloudinary(exam.value?.question);
+  const file = await getPdfFromUrl(exam.value?.question);
   await uploadDocument({
     file,
   }, false);

--- a/src/pages/Student/Student.vue
+++ b/src/pages/Student/Student.vue
@@ -57,9 +57,9 @@ const {
   = storeToRefs(documentStore);
 const {
   uploadDocument,
-  getPdfFromCloudinary,
+  getPdfFromUrl,
   generatePdfBlob,
-  uploadPdfToCloudinary,
+  uploadPdfToS3,
   setQuestions,
 } = documentStore;
 
@@ -118,7 +118,7 @@ async function handleExamSubmit() {
   const pdfBlob = await generatePdfBlob(html);
   const {
     url: secureUrl,
-  } = await uploadPdfToCloudinary(pdfBlob);
+  } = await uploadPdfToS3(pdfBlob);
   if (!secureUrl) {
     toggleSubmitExamModal();
     return;
@@ -203,7 +203,7 @@ onMounted(async () => {
     setQuestions(JSON.parse(stored));
   }
   else {
-    const file = await getPdfFromCloudinary(exam.value!.question);
+    const file = await getPdfFromUrl(exam.value!.question);
     await uploadDocument({
       file,
     }, false);

--- a/src/store/server/document.ts
+++ b/src/store/server/document.ts
@@ -166,31 +166,27 @@ export const useDocumentStore = defineStore("documents", {
       });
     },
 
-    async uploadPdfToCloudinary(pdfBlob: Blob) {
+    async uploadPdfToS3(pdfBlob: Blob) {
       try {
         this.success = false;
         this.loading = true;
 
-        const name = "dkzladmu2";
-        const unsignedPreset = "unsigned_pdf_upload";
-        const url = `https://api.cloudinary.com/v1_1/${name}/upload`;
         const formData = new FormData();
+        const file = new File([pdfBlob], "document.pdf", {
+          type: "application/pdf",
+        });
+        formData.append("file", file);
 
-        formData.append("file", pdfBlob);
-        formData.append("upload_preset", unsignedPreset);
-
-        const response = await fetch(url, {
-          method: "POST",
-          body: formData,
+        const {
+          data,
+        } = await axiosInstance.post("/aws/upload", formData, {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
         });
 
-        if (!response.ok) {
-          throw new Error(`Upload failed: ${response.statusText}`);
-        }
-
-        const data = await response.json();
         return {
-          url: data.secure_url,
+          url: data,
         };
       }
       catch {
@@ -201,7 +197,7 @@ export const useDocumentStore = defineStore("documents", {
       }
     },
 
-    async getPdfFromCloudinary(pdfUrl: string): Promise<File> {
+    async getPdfFromUrl(pdfUrl: string): Promise<File> {
       try {
         this.success = false;
         this.loading = true;


### PR DESCRIPTION
## Summary
- send generated PDFs to `/aws/upload` as multipart/form-data
- store S3 URL from server and use it in further requests
- replace Cloudinary helpers with generic `getPdfFromUrl`
- remove Cloudinary packages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848595332d0832eb9d5191de1e3aa41