### PR TITLE
Update student login flow to use email from localStorage

### DIFF
--- a/src/pages/Auth/StudentLogin.vue
+++ b/src/pages/Auth/StudentLogin.vue
@@ -63,7 +63,6 @@ async function onSubmit() {
       documentStore.setQuestions(parsed);
     }
 
-    document.cookie = `student=${data.access_token}; Path=/; Secure; SameSite=Strict`;
     localStorage.setItem("email", loginForm.email.toLowerCase());
 
     localStorage.setItem("examKey", loginForm.examKey);

--- a/src/pages/Student/Student.vue
+++ b/src/pages/Student/Student.vue
@@ -123,12 +123,7 @@ async function handleExamSubmit() {
     toggleSubmitExamModal();
     return;
   }
-  const cookie = document.cookie
-    .split("; ")
-    .find(c => c.startsWith("student="))!;
-  const token = cookie.split("=")[1];
-  const payload = JSON.parse(atob(token.split(".")[1]));
-  const email = payload.email as string;
+  const email = localStorage.getItem("email") as string;
   const examKey = localStorage.getItem("examKey") as string;
   const formData = new FormData();
   formData.append("file", pdfBlob, "submission.pdf");


### PR DESCRIPTION
## Summary
- remove cookie token usage in StudentLogin
- read student email from localStorage in Student page

## Testing
- `npm run lint`
- `npm run dev` *(fails: server requires manual interaction)*

------
https://chatgpt.com/codex/tasks/task_e_685b211fe1d0832e8fac37172b207932