### PR TITLE
Fix send transcript action missing

### DIFF
--- a/src/store/server/exam.ts
+++ b/src/store/server/exam.ts
@@ -291,6 +291,33 @@ export const useExamServerStore = defineStore("exam-server", {
       }
     },
 
+    async sendExamBackToStudent(examId: string, payload: string | Array<string>) {
+      try {
+        this.success = false;
+        this.loading = true;
+        const {
+          data,
+        } = await axiosInstance.post(`/exams/${examId}/send`, {
+          email: payload,
+        });
+        const {
+          message,
+        } = data;
+        this.success = true;
+        successToast(message);
+      }
+      catch (error: any) {
+        this.success = false;
+        const errorMessage
+          = error.response?.data?.message || error.message || "Network Error";
+        errorToast(errorMessage);
+        throw new Error(errorMessage);
+      }
+      finally {
+        this.loading = false;
+      }
+    },
+
     async scheduleExam(examId: string, startDate: string, startTime: string) {
       try {
         this.success = false;


### PR DESCRIPTION
## Summary
- restore `sendExamBackToStudent` action in `exam` store

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b9de33ec8832ead2d1a4702877133