### PR TITLE
Check auth token cookie on login

### DIFF
--- a/src/pages/Auth/Login.vue
+++ b/src/pages/Auth/Login.vue
@@ -4,6 +4,7 @@ import {
 } from "pinia";
 import {
   computed,
+  onMounted,
   reactive,
   ref,
 } from "vue";
@@ -14,6 +15,9 @@ import {
 import {
   useAuthStore,
 } from "../../store/server/auth";
+import {
+  getCookie,
+} from "../../utils/functions";
 
 const loginForm = reactive({
   email: "",
@@ -32,14 +36,24 @@ const isFormComplete = computed(() => {
   return loginForm.email !== "" && loginForm.password !== "";
 });
 const router = useRouter();
+const authStore = useAuthStore();
 const {
   login,
-} = useAuthStore();
+} = authStore;
 const {
   success: authSuccess,
   loading: authLoading,
-}
-  = storeToRefs(useAuthStore());
+} = storeToRefs(authStore);
+
+onMounted(() => {
+  const token = getCookie("token");
+  if (token) {
+    authStore.setAccessToken(token);
+    router.push({
+      name: "exams",
+    });
+  }
+});
 
 async function onSubmit() {
   await login(loginForm);

--- a/src/store/server/auth.ts
+++ b/src/store/server/auth.ts
@@ -131,7 +131,15 @@ export const useAuthStore = defineStore("auth", {
   getters: {
     getAuthToken(state) {
       const storageToken = localStorage.getItem("access");
-      return storageToken || state.access;
+      if (storageToken)
+        return storageToken;
+      const cookieToken = typeof document !== "undefined"
+        ? document.cookie
+          .split("; ")
+          .map(c => c.split("="))
+          .find(([name]) => name === "token")?.[1]
+        : null;
+      return cookieToken || state.access;
     },
   },
 });

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -99,3 +99,17 @@ export function downloadFile(fileName: string) {
   link.click();
   document.body.removeChild(link);
 }
+
+export function getCookie(name: string) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const cookieArr = document.cookie.split("; ");
+  for (const cookie of cookieArr) {
+    const [cookieName, cookieValue] = cookie.split("=");
+    if (cookieName === name) {
+      return cookieValue;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `getCookie` helper
- check for existing token cookie on login page
- update auth store to read token from cookie
- lint and build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686433111304832e96737fe92a4b198d