### PR TITLE
Fix admin store imports

### DIFF
--- a/admin/src/store/admin.ts
+++ b/admin/src/store/admin.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
-import { axiosInstance } from "../../src/utils/axiosConfig";
-import { errorToast, successToast } from "../../src/utils/toast";
-import type { BaseState } from "../../src/utils/types";
+import { axiosInstance } from "../../../src/utils/axiosConfig";
+import { errorToast, successToast } from "../../../src/utils/toast";
+import type { BaseState } from "../../../src/utils/types";
 
 export interface User {
   _id: string;


### PR DESCRIPTION
## Summary
- fix relative paths for axios, toast, and types imports in admin store

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869ab3898a4832e95458db958ab0043